### PR TITLE
Fixes `bidlist.MoveToBack` and `bidlist.MoveToFront`

### DIFF
--- a/ds/list/bidlist/list.go
+++ b/ds/list/bidlist/list.go
@@ -228,6 +228,9 @@ func (l *List) MoveToBack(n *Node) {
 		return
 	}
 	if l.head.prev != n {
+		if l.head == n {
+			l.head = n.next
+		}
 		l.moveToAfter(n, l.head.prev)
 	}
 }
@@ -243,7 +246,7 @@ func (l *List) MoveAfter(n, mark *Node) {
 }
 
 func (l *List) moveToAfter(n, at *Node) {
-	if n == at.next {
+	if n == at.next || n == at {
 		return
 	}
 	if n == l.head {

--- a/ds/list/bidlist/list_test.go
+++ b/ds/list/bidlist/list_test.go
@@ -64,6 +64,18 @@ func TestList(t *testing.T) {
 	list.MoveToFront(list.FrontNode().Next())
 	assert.Equal(t, "[5 7 2 1 8]", list.String())
 
+	list.MoveToFront(list.BackNode())
+	assert.Equal(t, "[8 5 7 2 1]", list.String())
+
+	list.MoveToBack(list.FrontNode())
+	assert.Equal(t, "[5 7 2 1 8]", list.String())
+
+	list.MoveToFront(list.FrontNode())
+	assert.Equal(t, "[5 7 2 1 8]", list.String())
+
+	list.MoveToBack(list.BackNode())
+	assert.Equal(t, "[5 7 2 1 8]", list.String())
+
 	list.moveToAfter(list.FrontNode().Next(), list.BackNode().Prev())
 	assert.Equal(t, "[5 2 1 7 8]", list.String())
 


### PR DESCRIPTION
1. `bidlist.MoveToFront(bidlist.BackNode())` would turn `[5 7 2 1 8]` into `[8]` (and of course internal pointers are broken);
2. `bidlist.MoveToBack(bidlist.FrontNode())` does nothing, although, semantically, most people should want `bidlist.head` to point to `bidlist.head.next` by doing this.