### PR TITLE
Features: Erase method for Multiset now remove only one instance of the element similar to `iterator erase( iterator pos )` for c++ data structure `std::multiset`.

### DIFF
--- a/ds/rbtree/rbtree.go
+++ b/ds/rbtree/rbtree.go
@@ -45,6 +45,11 @@ func (t *RbTree[K, V]) FindNode(key K) *Node[K, V] {
 	return t.findFirstNode(key)
 }
 
+// Compare compares two keys wrt the RbTree's key comparator
+func (t *RbTree[K, V]) Compare(key1, key2 K) int {
+	return t.keyCmp(key1, key2)
+}
+
 // Begin returns the node with minimum key in the RbTree
 func (t *RbTree[K, V]) Begin() *Node[K, V] {
 	return t.First()

--- a/ds/rbtree/rbtree_test.go
+++ b/ds/rbtree/rbtree_test.go
@@ -179,3 +179,10 @@ func TestNode(t *testing.T) {
 		i++
 	}
 }
+
+func TestRbTreeCompare(t *testing.T) {
+	tree := New[int, int](comparator.IntComparator)
+	assert.Equal(t, 0, tree.Compare(1, 1))
+	assert.Equal(t, -1, tree.Compare(1, 2))
+	assert.Equal(t, 1, tree.Compare(2, 1))
+}

--- a/ds/set/multiset.go
+++ b/ds/set/multiset.go
@@ -2,6 +2,7 @@ package set
 
 import (
 	"fmt"
+
 	"github.com/liyue201/gostl/ds/rbtree"
 	"github.com/liyue201/gostl/utils/comparator"
 	"github.com/liyue201/gostl/utils/sync"
@@ -36,8 +37,19 @@ func (ms *MultiSet[T]) Insert(element T) {
 	ms.tree.Insert(element, Empty)
 }
 
-// Erase erases all node with passed element in the MultiSet
+// Erase erases the first node with passed element in the MultiSet
 func (ms *MultiSet[T]) Erase(element T) {
+	ms.locker.Lock()
+	defer ms.locker.Unlock()
+
+	node := ms.tree.FindNode(element)
+	if node != nil {
+		ms.tree.Delete(node)
+	}
+}
+
+// Erase erases all node with passed element in the MultiSet
+func (ms *MultiSet[T]) EraseAll(element T) {
 	ms.locker.Lock()
 	defer ms.locker.Unlock()
 
@@ -59,7 +71,7 @@ func (ms *MultiSet[T]) Find(element T) *SetIterator[T] {
 	return &SetIterator[T]{node: node}
 }
 
-//LowerBound finds the first element that is equal to or greater than the passed element in the MultiSet, and returns its iterator
+// LowerBound finds the first element that is equal to or greater than the passed element in the MultiSet, and returns its iterator
 func (ms *MultiSet[T]) LowerBound(element T) *SetIterator[T] {
 	ms.locker.RLock()
 	defer ms.locker.RUnlock()
@@ -68,7 +80,7 @@ func (ms *MultiSet[T]) LowerBound(element T) *SetIterator[T] {
 	return &SetIterator[T]{node: node}
 }
 
-//UpperBound finds the first element that is greater than the passed element in the MultiSet, and returns its iterator
+// UpperBound finds the first element that is greater than the passed element in the MultiSet, and returns its iterator
 func (ms *MultiSet[T]) UpperBound(element T) *SetIterator[T] {
 	ms.locker.RLock()
 	defer ms.locker.RUnlock()
@@ -90,12 +102,26 @@ func (ms *MultiSet[T]) First() *SetIterator[T] {
 	return &SetIterator[T]{node: ms.tree.First()}
 }
 
-//Last returns the iterator with the maximum element in the MultiSet
+// Last returns the iterator with the maximum element in the MultiSet
 func (ms *MultiSet[T]) Last() *SetIterator[T] {
 	ms.locker.RLock()
 	defer ms.locker.RUnlock()
 
 	return &SetIterator[T]{node: ms.tree.Last()}
+}
+
+// Count returns the amount of elements that are equal to the passed element in the MultiSet
+func (ms *MultiSet[T]) Count(element T) int {
+	ms.locker.RLock()
+	defer ms.locker.RUnlock()
+
+	count := 0
+	for node := ms.tree.First(); node != nil; node = node.Next() {
+		if ms.tree.Compare(node.Key(), element) == 0 {
+			count++
+		}
+	}
+	return count
 }
 
 // Clear clears all elements in the MultiSet

--- a/ds/set/multiset_test.go
+++ b/ds/set/multiset_test.go
@@ -23,7 +23,14 @@ func TestMultiSet(t *testing.T) {
 		t.Logf("%v\n", iter.Value())
 	}
 	assert.Equal(t, "[1 1 5]", mset.String())
-	mset.Erase(1)
+	mset.EraseAll(1)
+	assert.Equal(t, "[5]", mset.String())
+
+	mset.Insert(5)
+	assert.Equal(t, 2, mset.Count(5))
+	assert.Equal(t, "[5 5]", mset.String())
+	mset.Erase(5)
+	assert.Equal(t, 1, mset.Count(5))
 	assert.Equal(t, "[5]", mset.String())
 
 	mset.Clear()


### PR DESCRIPTION
In details, the new features are:
- Multiset: Changed Erase method to remove only one instance of the element (not all of them) similar to `iterator erase( iterator pos )` for c++ data structure `std::multiset`.
- Multiset: Added EraseAll method to remove all instances of the element. It replaces the previous implementation of Erase method.
- Multiset: Added Count method that returns the number of instances of the element in the multiset.
- RbTree: Added Compare method that compare two keys w.r.t. the comparator of the tree.