### PR TITLE
feat: Official Iterator support for Go1.23+ & minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ func main() {
   for iter := a.Begin(); iter.IsValid(); iter.Next() {
     fmt.Printf("%v ", iter.Value())
   }
+
+  // Go 1.23+
+  for v := range a.Iter() {
+    fmt.Printf("%v ", v)
+  }
 }
 
 ```
@@ -136,6 +141,11 @@ func main() {
   for iter := v.Begin(); iter.IsValid(); iter.Next() {
     fmt.Printf("%v ", iter.Value())
   }
+
+  // Go 1.23+
+  for v := range v.Iter() {
+    fmt.Printf("%v ", v)
+  }
 }
 
 ```
@@ -163,6 +173,11 @@ func main() {
     fmt.Printf("%v ", n.Value)
   }
   fmt.Printf("\n===============\n")
+
+  // Go 1.23+
+  for n := range l.Iter() {
+    fmt.Printf("%v ", n.Value)
+  }
 }
 
 ```
@@ -190,6 +205,11 @@ func main() {
   fmt.Printf("\n")
 
   for n := l.BackNode(); n != nil; n = n.Prev() {
+    fmt.Printf("%v ", n.Value)
+  }
+
+  // Go 1.23+
+  for n := range l.Iter() {
     fmt.Printf("%v ", n.Value)
   }
 }
@@ -226,6 +246,11 @@ func main() {
     q.EraseAt(r)
   }
   fmt.Printf("%v\n", q)
+
+  // Go 1.23+
+  for v := range q.Iter() {
+    fmt.Printf("%v ", v)
+  }
 }
 
 ```
@@ -328,6 +353,11 @@ func main() {
     return true
   })
   tree.Delete(tree.FindNode(3))
+
+  // Go 1.23+
+  for k, v := range tree.Iter2() {
+    fmt.Printf("%v : %v\n", k, v)
+  }
 }
 
 ```
@@ -356,6 +386,11 @@ func main() {
   fmt.Printf("b = %v\n", b)
 
   m.Erase("b")
+
+  // Go 1.23+
+  for k, v := range m.Iter2() {
+    fmt.Printf("%v : %v\n", k, v)
+  }
 }
 
 ```
@@ -388,6 +423,11 @@ func main() {
 
   fmt.Printf("%v\n", s.Contains(3))
   fmt.Printf("%v\n", s.Contains(10))
+
+  // Go 1.23+
+  for v := range s.Iter() {
+    fmt.Printf("%v\n", v)
+  }
 }
 
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -28,7 +28,7 @@ GoSTL是一个go语言数据结构和算法库，类似C++的STL，但功能更�
     - [布隆过滤器（bloom_filter）](#bloom_filter)
     - [哈希数组映射字典树（hash_array_mapped_trie）](#hamt)
     - [一致性哈希（ketama）](#ketama)
-    - [跳表（skiplist）](#skliplist)
+    - [跳表（skiplist）](#skiplist)
 - 算法
     - [快排（sort）](#sort)
     - [稳定排序（stable_sort）](#sort)
@@ -103,6 +103,11 @@ func main() {
   for iter := a.Begin(); iter.IsValid(); iter.Next() {
     fmt.Printf("%v ", iter.Value())
   }
+
+  // Go 1.23+
+  for v := range a.Iter() {
+    fmt.Printf("%v ", v)
+  }
 }
 
 ```
@@ -135,6 +140,11 @@ func main() {
   for iter := v.Begin(); iter.IsValid(); iter.Next() {
     fmt.Printf("%v ", iter.Value())
   }
+
+  // Go 1.23+
+  for value := range v.Iter() {
+    fmt.Printf("%v ", value)
+  }
 }
 
 ```
@@ -163,6 +173,11 @@ func main() {
     fmt.Printf("%v ", n.Value)
   }
   fmt.Printf("\n===============\n")
+
+  // Go 1.23+
+  for value := range l.Iter() {
+    fmt.Printf("%v ", value)
+  }
 }
 ```
   
@@ -186,6 +201,11 @@ func main() {
     fmt.Printf("%v ", n.Value)
   }
   fmt.Printf("\n")
+
+  // Go 1.23+
+  for v := range l.Iter() {
+    fmt.Printf("%v ", v)
+  }
 
   for n := l.BackNode(); n != nil; n = n.Prev() {
     fmt.Printf("%v ", n.Value)
@@ -224,6 +244,11 @@ func main() {
     q.EraseAt(r)
   }
   fmt.Printf("%v\n", q)
+
+  // Go 1.23+
+  for v := range q.Iter() {
+    fmt.Printf("%v ", v)
+  }
 }
 
 ```
@@ -325,6 +350,11 @@ func main() {
     return true
   })
   tree.Delete(tree.FindNode(3))
+
+  // Go 1.23+
+  for k, v := range tree.Iter2() {
+    fmt.Printf("%v : %v\n", k, v)
+  }
 }
 
 
@@ -354,6 +384,11 @@ func main() {
   fmt.Printf("b = %v\n", b)
 
   m.Erase("b")
+
+  // Go 1.23+
+  for k, v := range m.Iter2() {
+    fmt.Printf("%v : %v\n", k, v)
+  }
 }
 
 ```
@@ -386,6 +421,11 @@ func main() {
 
   fmt.Printf("%v\n", s.Contains(3))
   fmt.Printf("%v\n", s.Contains(10))
+
+  // Go 1.23+
+  for v := range s.Iter() {
+    fmt.Printf("%v\n", v)
+  }
 }
 
 ```
@@ -489,7 +529,7 @@ func main() {
 
 
 ```
-### <a name="skliplist">跳表（skliplist）</a>
+### <a name="skiplist">跳表（skiplist）</a>
 跳表是一种通过以空间换时间来实现快速查找的数据结构。支持线程安全。
 
 ```go

--- a/ds/array/array_iter_go123.go
+++ b/ds/array/array_iter_go123.go
@@ -1,0 +1,65 @@
+//go:build go1.23
+
+package array
+
+import "iter"
+
+// Iter() provides a range-based immutable for loop. Example:
+//
+//	for v := range a.Iter() {
+//		fmt.Println(v)
+//	}
+func (a *Array[T]) Iter() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for _, v := range a.values {
+			if !yield(v) {
+				break
+			}
+		}
+	}
+}
+
+// IterMut() provides a range-based mutable for loop. Example:
+//
+//	for vPtr := range a.IterMut() {
+//		*vPtr = newValue
+//	}
+func (a *Array[T]) IterMut() iter.Seq[*T] {
+	return func(yield func(*T) bool) {
+		for i := range a.values {
+			if !yield(&a.values[i]) {
+				break
+			}
+		}
+	}
+}
+
+// Iter2() provides a range-based immutable for loop with index. Example:
+//
+//	for i, v := range a.Iter2() {
+//		fmt.Println(i, v)
+//	}
+func (a *Array[T]) Iter2() iter.Seq2[int, T] {
+	return func(yield func(int, T) bool) {
+		for i, v := range a.values {
+			if !yield(i, v) {
+				break
+			}
+		}
+	}
+}
+
+// IterMut2() provides a range-based mutable for loop with index. Example:
+//
+//	for i, vPtr := range a.IterMut2() {
+//		*vPtr = newValue
+//	}
+func (a *Array[T]) IterMut2() iter.Seq2[int, *T] {
+	return func(yield func(int, *T) bool) {
+		for i := range a.values {
+			if !yield(i, &a.values[i]) {
+				break
+			}
+		}
+	}
+}

--- a/ds/array/array_iter_go123_test.go
+++ b/ds/array/array_iter_go123_test.go
@@ -1,0 +1,27 @@
+//go:build go1.23
+
+package array
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIter(t *testing.T) {
+	a := New[int](10)
+	n := 0
+	for ptr := range a.IterMut() {
+		*ptr = n
+		n++
+	}
+	assert.Equal(t, 2, a.At(2))
+	assert.Equal(t, 0, a.Front())
+	assert.Equal(t, 9, a.Back())
+
+	n = 0
+	for val := range a.Iter() {
+		assert.Equal(t, n, val)
+		n++
+	}
+}

--- a/ds/deque/deque_iter_go123.go
+++ b/ds/deque/deque_iter_go123.go
@@ -1,0 +1,73 @@
+//go:build go1.23
+
+package deque
+
+import "iter"
+
+// Iter() provides a range-based immutable for loop. Example:
+//
+//	for v := range d.Iter() {
+//		fmt.Println(v)
+//	}
+func (d *Deque[T]) Iter() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for i := range d.Size() {
+			if !yield(d.At(i)) {
+				break
+			}
+		}
+	}
+}
+
+// IterMut() provides a range-based mutable for loop. Example:
+//
+//	for vPtr := range d.IterMut() {
+//		*vPtr = newValue
+//	}
+func (d *Deque[T]) IterMut() iter.Seq[*T] {
+	return func(yield func(*T) bool) {
+		for i := range d.Size() {
+			seg, pos := d.pos(i)
+			s := d.segmentAt(seg)
+			ptr := &s.data[(pos+s.begin)%s.capacity()]
+			if !yield(ptr) {
+				break
+			}
+		}
+	}
+}
+
+// Iter2() provides a range-based immutable for loop with index. Example:
+//
+//	for i, v := range d.Iter2() {
+//		fmt.Println(i, v)
+//	}
+func (d *Deque[T]) Iter2() iter.Seq2[int, T] {
+	return func(yield func(int, T) bool) {
+		for i := range d.Size() {
+			seg, pos := d.pos(i)
+			s := d.segmentAt(seg)
+			if !yield(i, s.at(pos)) {
+				break
+			}
+		}
+	}
+}
+
+// IterMut2() provides a range-based mutable for loop with index. Example:
+//
+//	for i, vPtr := range d.IterMut2() {
+//		*vPtr = newValue
+//	}
+func (d *Deque[T]) IterMut2() iter.Seq2[int, *T] {
+	return func(yield func(int, *T) bool) {
+		for i := range d.Size() {
+			seg, pos := d.pos(i)
+			s := d.segmentAt(seg)
+			ptr := &s.data[(pos+s.begin)%s.capacity()]
+			if !yield(i, ptr) {
+				break
+			}
+		}
+	}
+}

--- a/ds/deque/deque_iter_go123_test.go
+++ b/ds/deque/deque_iter_go123_test.go
@@ -1,0 +1,31 @@
+//go:build go1.23
+
+package deque
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIter(t *testing.T) {
+	q := New[int]()
+	for i := 0; i < 10; i++ {
+		q.PushBack(i)
+	}
+	n := 0
+	for v := range q.Iter() {
+		assert.Equal(t, n, v)
+		n++
+	}
+
+	for v := range q.IterMut() {
+		*v *= 2
+	}
+
+	n = 0
+	for v := range q.Iter() {
+		assert.Equal(t, n*2, v)
+		n++
+	}
+}

--- a/ds/list/bidlist/list_iter_go123.go
+++ b/ds/list/bidlist/list_iter_go123.go
@@ -1,0 +1,69 @@
+//go:build go1.23
+
+package bidlist
+
+import "iter"
+
+// Iter() provides a range-based immutable for loop. Example:
+//
+//	for v := range l.Iter() {
+//		fmt.Println(v)
+//	}
+func (l *List[T]) Iter() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for n := l.FrontNode(); n != nil; n = n.Next() {
+			if !yield(n.Value) {
+				break
+			}
+		}
+	}
+}
+
+// IterMut() provides a range-based mutable for loop. Example:
+//
+//	for vPtr := range l.IterMut() {
+//		*vPtr = newValue
+//	}
+func (l *List[T]) IterMut() iter.Seq[*T] {
+	return func(yield func(*T) bool) {
+		for n := l.FrontNode(); n != nil; n = n.Next() {
+			if !yield(&n.Value) {
+				break
+			}
+		}
+	}
+}
+
+// Iter2() provides a range-based immutable for loop with index. Example:
+//
+//	for i, v := range l.Iter2() {
+//		fmt.Println(i, v)
+//	}
+func (l *List[T]) Iter2() iter.Seq2[int, T] {
+	return func(yield func(int, T) bool) {
+		total := 0
+		for n := l.FrontNode(); n != nil; n = n.Next() {
+			if !yield(total, n.Value) {
+				break
+			}
+			total++
+		}
+	}
+}
+
+// IterMut2() provides a range-based mutable for loop with index. Example:
+//
+//	for i, vPtr := range l.IterMut2() {
+//		*vPtr = newValue
+//	}
+func (l *List[T]) IterMut2() iter.Seq2[int, *T] {
+	return func(yield func(int, *T) bool) {
+		total := 0
+		for n := l.FrontNode(); n != nil; n = n.Next() {
+			if !yield(total, &n.Value) {
+				break
+			}
+			total++
+		}
+	}
+}

--- a/ds/list/bidlist/list_iter_go123_test.go
+++ b/ds/list/bidlist/list_iter_go123_test.go
@@ -1,0 +1,31 @@
+//go:build go1.23
+
+package bidlist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIter(t *testing.T) {
+	list := New[int]()
+	for i := 1; i <= 5; i++ {
+		list.PushBack(i)
+	}
+	i := 1
+	for v := range list.Iter() {
+		assert.Equal(t, i, v)
+		i++
+	}
+
+	for v := range list.IterMut() {
+		*v *= 2
+	}
+
+	i = 1
+	for v := range list.Iter() {
+		assert.Equal(t, i*2, v)
+		i++
+	}
+}

--- a/ds/list/simplelist/list_iter_go123.go
+++ b/ds/list/simplelist/list_iter_go123.go
@@ -1,0 +1,69 @@
+//go:build go1.23
+
+package simplelist
+
+import "iter"
+
+// Iter() provides a range-based immutable for loop. Example:
+//
+//	for v := range l.Iter() {
+//		fmt.Println(v)
+//	}
+func (l *List[T]) Iter() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for n := l.FrontNode(); n != nil; n = n.Next() {
+			if !yield(n.Value) {
+				break
+			}
+		}
+	}
+}
+
+// IterMut() provides a range-based mutable for loop. Example:
+//
+//	for vPtr := range l.IterMut() {
+//		*vPtr = newValue
+//	}
+func (l *List[T]) IterMut() iter.Seq[*T] {
+	return func(yield func(*T) bool) {
+		for n := l.FrontNode(); n != nil; n = n.Next() {
+			if !yield(&n.Value) {
+				break
+			}
+		}
+	}
+}
+
+// Iter2() provides a range-based immutable for loop with index. Example:
+//
+//	for i, v := range l.Iter2() {
+//		fmt.Println(i, v)
+//	}
+func (l *List[T]) Iter2() iter.Seq2[int, T] {
+	return func(yield func(int, T) bool) {
+		total := 0
+		for n := l.FrontNode(); n != nil; n = n.Next() {
+			if !yield(total, n.Value) {
+				break
+			}
+			total++
+		}
+	}
+}
+
+// IterMut2() provides a range-based mutable for loop with index. Example:
+//
+//	for i, vPtr := range l.IterMut2() {
+//		*vPtr = newValue
+//	}
+func (l *List[T]) IterMut2() iter.Seq2[int, *T] {
+	return func(yield func(int, *T) bool) {
+		total := 0
+		for n := l.FrontNode(); n != nil; n = n.Next() {
+			if !yield(total, &n.Value) {
+				break
+			}
+			total++
+		}
+	}
+}

--- a/ds/list/simplelist/list_iter_go123_test.go
+++ b/ds/list/simplelist/list_iter_go123_test.go
@@ -1,0 +1,31 @@
+//go:build go1.23
+
+package simplelist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIter(t *testing.T) {
+	list := New[int]()
+	for i := 1; i <= 5; i++ {
+		list.PushBack(i)
+	}
+	i := 1
+	for v := range list.Iter() {
+		assert.Equal(t, i, v)
+		i++
+	}
+
+	for v := range list.IterMut() {
+		*v *= 2
+	}
+
+	i = 1
+	for v := range list.Iter() {
+		assert.Equal(t, i*2, v)
+		i++
+	}
+}

--- a/ds/map/iter_go123.go
+++ b/ds/map/iter_go123.go
@@ -1,0 +1,71 @@
+//go:build go1.23
+
+package treemap
+
+import "iter"
+
+// Iter() provides a range-based immutable for loop over keys. Example:
+//
+//	for k := range m.Iter() {
+//		fmt.Println(k)
+//	}
+func (m *Map[K, V]) Iter() iter.Seq[K] {
+	m.locker.RLock()
+	defer m.locker.RUnlock()
+	return m.tree.Iter()
+}
+
+// Iter2() provides a range-based immutable for loop over key-value pairs. Example:
+//
+//	for k, v := range m.Iter2() {
+//		fmt.Println(k, v)
+//	}
+func (m *Map[K, V]) Iter2() iter.Seq2[K, V] {
+	m.locker.RLock()
+	defer m.locker.RUnlock()
+	return m.tree.Iter2()
+}
+
+// IterMut2() provides a range-based mutable for loop over key-value pairs. Example:
+//
+//	for k, vPtr := range m.IterMut2() {
+//		*vPtr = newValue
+//	}
+func (m *Map[K, V]) IterMut2() iter.Seq2[K, *V] {
+	m.locker.Lock()
+	defer m.locker.Unlock()
+	return m.tree.IterMut2()
+}
+
+// Iter() provides a range-based immutable for loop over keys. Example:
+//
+//	for k := range m.Iter() {
+//		fmt.Println(k)
+//	}
+func (m *MultiMap[K, V]) Iter() iter.Seq[K] {
+	m.locker.RLock()
+	defer m.locker.RUnlock()
+	return m.tree.Iter()
+}
+
+// Iter2() provides a range-based immutable for loop over key-value pairs. Example:
+//
+//	for k, v := range m.Iter2() {
+//		fmt.Println(k, v)
+//	}
+func (m *MultiMap[K, V]) Iter2() iter.Seq2[K, V] {
+	m.locker.RLock()
+	defer m.locker.RUnlock()
+	return m.tree.Iter2()
+}
+
+// IterMut2() provides a range-based mutable for loop over key-value pairs. Example:
+//
+//	for k, vPtr := range m.IterMut2() {
+//		*vPtr = newValue
+//	}
+func (m *MultiMap[K, V]) IterMut2() iter.Seq2[K, *V] {
+	m.locker.Lock()
+	defer m.locker.Unlock()
+	return m.tree.IterMut2()
+}

--- a/ds/map/iter_go123_test.go
+++ b/ds/map/iter_go123_test.go
@@ -1,0 +1,40 @@
+//go:build go1.23
+
+package treemap
+
+import (
+	"testing"
+
+	"github.com/liyue201/gostl/utils/comparator"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapIter(t *testing.T) {
+	m := New[int, int](comparator.IntComparator, WithGoroutineSafe())
+
+	for i := 1; i <= 10; i++ {
+		m.Insert(i, i)
+	}
+
+	i := 1
+	for k, v := range m.Iter2() {
+		assert.Equal(t, i, k)
+		assert.Equal(t, i, v)
+		i++
+	}
+}
+
+func TestMultiMapIter(t *testing.T) {
+	m := NewMultiMap[int, int](comparator.IntComparator, WithGoroutineSafe())
+
+	for i := 1; i <= 10; i++ {
+		m.Insert(i, i)
+	}
+
+	i := 1
+	for k, v := range m.Iter2() {
+		assert.Equal(t, i, k)
+		assert.Equal(t, i, v)
+		i++
+	}
+}

--- a/ds/map/multimap.go
+++ b/ds/map/multimap.go
@@ -7,7 +7,7 @@ import (
 	"github.com/liyue201/gostl/utils/visitor"
 )
 
-// MultiMap uses RbTress for internal data structure, and keys can bee repeated.
+// MultiMap uses RbTress for internal data structure, and keys can be repeated.
 type MultiMap[K, V any] struct {
 	tree   *rbtree.RbTree[K, V]
 	locker sync.Locker

--- a/ds/rbtree/rbtree_iter_go123.go
+++ b/ds/rbtree/rbtree_iter_go123.go
@@ -1,0 +1,50 @@
+//go:build go1.23
+
+package rbtree
+
+import "iter"
+
+// Iter() provides a range-based immutable for loop over keys. Example:
+//
+//	for k := range t.Iter() {
+//		fmt.Println(k)
+//	}
+func (t *RbTree[K, V]) Iter() iter.Seq[K] {
+	return func(yield func(K) bool) {
+		for n := t.First(); n != nil; n = n.Next() {
+			if !yield(n.Key()) {
+				break
+			}
+		}
+	}
+}
+
+// Iter2() provides a range-based immutable for loop over key-value pairs. Example:
+//
+//	for k, v := range t.Iter2() {
+//		fmt.Println(k, v)
+//	}
+func (t *RbTree[K, V]) Iter2() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		for n := t.First(); n != nil; n = n.Next() {
+			if !yield(n.Key(), n.Value()) {
+				break
+			}
+		}
+	}
+}
+
+// IterMut2() provides a range-based mutable for loop over key-value pairs. Example:
+//
+//	for k, vPtr := range t.IterMut2() {
+//		*vPtr = newValue
+//	}
+func (t *RbTree[K, V]) IterMut2() iter.Seq2[K, *V] {
+	return func(yield func(K, *V) bool) {
+		for n := t.First(); n != nil; n = n.Next() {
+			if !yield(n.Key(), &n.value) {
+				break
+			}
+		}
+	}
+}

--- a/ds/rbtree/rbtree_iter_go123_test.go
+++ b/ds/rbtree/rbtree_iter_go123_test.go
@@ -1,0 +1,34 @@
+//go:build go1.23
+
+package rbtree
+
+import (
+	"testing"
+
+	"github.com/liyue201/gostl/utils/comparator"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIter(t *testing.T) {
+	tree := New[int, int](comparator.IntComparator)
+	for i := 0; i < 10; i++ {
+		tree.Insert(i, i+100)
+	}
+
+	i := 0
+	for k, v := range tree.Iter2() {
+		assert.Equal(t, i, k)
+		assert.Equal(t, i+100, v)
+		i++
+	}
+
+	for _, vPtr := range tree.IterMut2() {
+		*vPtr *= 2
+	}
+	i = 0
+	for k, v := range tree.Iter2() {
+		assert.Equal(t, i, k)
+		assert.Equal(t, (i+100)*2, v)
+		i++
+	}
+}

--- a/ds/set/iter_go123.go
+++ b/ds/set/iter_go123.go
@@ -1,0 +1,24 @@
+//go:build go1.23
+
+package set
+
+import "iter"
+
+// Iter() provides a range-based immutable for loop. Example:
+//
+//	for v := range s.Iter() {
+//		fmt.Println(v)
+//	}
+func (s *Set[T]) Iter() iter.Seq[T] {
+	s.locker.RLock()
+	defer s.locker.RUnlock()
+
+	return s.tree.Iter()
+}
+
+func (s *MultiSet[T]) Iter() iter.Seq[T] {
+	s.locker.RLock()
+	defer s.locker.RUnlock()
+
+	return s.tree.Iter()
+}

--- a/ds/set/iter_go123_test.go
+++ b/ds/set/iter_go123_test.go
@@ -1,0 +1,40 @@
+//go:build go1.23
+
+package set
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/liyue201/gostl/utils/comparator"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetIter(t *testing.T) {
+	s := New(comparator.IntComparator, WithGoroutineSafe())
+	for i := 0; i < 10; i++ {
+		s.Insert(i)
+	}
+
+	l := make([]int, 0)
+	for v := range s.Iter() {
+		l = append(l, v)
+	}
+	sort.Ints(l)
+	assert.Equal(t, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, l)
+}
+
+func TestMultiSetIter(t *testing.T) {
+	mset := NewMultiSet(comparator.IntComparator, WithGoroutineSafe())
+
+	mset.Insert(1)
+	mset.Insert(5)
+	mset.Insert(1)
+
+	l := make([]int, 0)
+	for v := range mset.Iter() {
+		l = append(l, v)
+	}
+	sort.Ints(l)
+	assert.Equal(t, []int{1, 1, 5}, l)
+}

--- a/ds/set/set.go
+++ b/ds/set/set.go
@@ -110,6 +110,9 @@ func (s *Set[T]) UpperBound(element T) *SetIterator[T] {
 
 // Begin returns the iterator with the minimum element in the set
 func (s *Set[T]) Begin() *SetIterator[T] {
+	s.locker.RLock()
+	defer s.locker.RUnlock()
+
 	return s.First()
 }
 

--- a/ds/slice/slice_iter_go123.go
+++ b/ds/slice/slice_iter_go123.go
@@ -1,0 +1,65 @@
+//go:build go1.23
+
+package slice
+
+import "iter"
+
+// Iter() provides a range-based immutable for loop. Example:
+//
+//	for v := range s.Iter() {
+//		fmt.Println(v)
+//	}
+func (s *SliceWrapper[T]) Iter() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for i := range s.Len() {
+			if !yield(s.slice[i]) {
+				break
+			}
+		}
+	}
+}
+
+// IterMut() provides a range-based mutable for loop. Example:
+//
+//	for vPtr := range s.IterMut() {
+//		*vPtr = newValue
+//	}
+func (s *SliceWrapper[T]) IterMut() iter.Seq[*T] {
+	return func(yield func(*T) bool) {
+		for i := range s.Len() {
+			if !yield(&s.slice[i]) {
+				break
+			}
+		}
+	}
+}
+
+// Iter2() provides a range-based immutable for loop with index. Example:
+//
+//	for i, v := range s.Iter2() {
+//		fmt.Println(i, v)
+//	}
+func (s *SliceWrapper[T]) Iter2() iter.Seq2[int, T] {
+	return func(yield func(int, T) bool) {
+		for i := range s.Len() {
+			if !yield(i, s.slice[i]) {
+				break
+			}
+		}
+	}
+}
+
+// IterMut2() provides a range-based mutable for loop with index. Example:
+//
+//	for i, vPtr := range s.IterMut2() {
+//		*vPtr = newValue
+//	}
+func (s *SliceWrapper[T]) IterMut2() iter.Seq2[int, *T] {
+	return func(yield func(int, *T) bool) {
+		for i := range s.Len() {
+			if !yield(i, &s.slice[i]) {
+				break
+			}
+		}
+	}
+}

--- a/ds/slice/slice_iter_go123_test.go
+++ b/ds/slice/slice_iter_go123_test.go
@@ -1,0 +1,34 @@
+//go:build go1.23
+
+package slice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSliceIter(t *testing.T) {
+	a := make([]int, 0, 10)
+	for i := 0; i < 10; i++ {
+		a = append(a, i)
+	}
+	sliceA := NewSliceWrapper(a)
+
+	l := make([]int, 0)
+	for v := range sliceA.Iter() {
+		l = append(l, v)
+	}
+	assert.Equal(t, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, l)
+
+	// mut
+	for vPtr := range sliceA.IterMut() {
+		*vPtr *= 2
+	}
+
+	l = make([]int, 0)
+	for v := range sliceA.Iter() {
+		l = append(l, v)
+	}
+	assert.Equal(t, []int{0, 2, 4, 6, 8, 10, 12, 14, 16, 18}, l)
+}

--- a/ds/vector/vector_iter_go123.go
+++ b/ds/vector/vector_iter_go123.go
@@ -1,0 +1,65 @@
+//go:build go1.23
+
+package vector
+
+import "iter"
+
+// Iter() provides a range-based immutable for loop. Example:
+//
+//	for v := range v.Iter() {
+//		fmt.Println(v)
+//	}
+func (v *Vector[T]) Iter() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for i := range v.Size() {
+			if !yield(v.data[i]) {
+				break
+			}
+		}
+	}
+}
+
+// IterMut() provides a range-based mutable for loop. Example:
+//
+//	for vPtr := range v.IterMut() {
+//		*vPtr = newValue
+//	}
+func (v *Vector[T]) IterMut() iter.Seq[*T] {
+	return func(yield func(*T) bool) {
+		for i := range v.Size() {
+			if !yield(&v.data[i]) {
+				break
+			}
+		}
+	}
+}
+
+// Iter2() provides a range-based immutable for loop with index. Example:
+//
+//	for i, v := range v.Iter2() {
+//		fmt.Println(i, v)
+//	}
+func (v *Vector[T]) Iter2() iter.Seq2[int, T] {
+	return func(yield func(int, T) bool) {
+		for i := range v.Size() {
+			if !yield(i, v.data[i]) {
+				break
+			}
+		}
+	}
+}
+
+// IterMut2() provides a range-based mutable for loop with index. Example:
+//
+//	for i, vPtr := range v.IterMut2() {
+//		*vPtr = newValue
+//	}
+func (v *Vector[T]) IterMut2() iter.Seq2[int, *T] {
+	return func(yield func(int, *T) bool) {
+		for i := range v.Size() {
+			if !yield(i, &v.data[i]) {
+				break
+			}
+		}
+	}
+}

--- a/ds/vector/vector_iter_go123_test.go
+++ b/ds/vector/vector_iter_go123_test.go
@@ -1,0 +1,35 @@
+//go:build go1.23
+
+package vector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVectorIter(t *testing.T) {
+	v := New[int]()
+	v.PushBack(1)
+	v.PushBack(2)
+	v.PushBack(3)
+	v.PushBack(4)
+	//[1 2 3 4]
+
+	i := 0
+	for v := range v.Iter() {
+		assert.Equal(t, i+1, v)
+		i++
+	}
+
+	// mut
+	for vPtr := range v.IterMut() {
+		*vPtr *= 2
+	}
+
+	i = 0
+	for v := range v.Iter() {
+		assert.Equal(t, (i+1)*2, v)
+		i++
+	}
+}

--- a/ds/vector/vector_test.go
+++ b/ds/vector/vector_test.go
@@ -77,7 +77,7 @@ func TestModifyVector(t *testing.T) {
 	v.Clear()
 }
 
-func TestVectorIter(t *testing.T) {
+func TestVectorIterator(t *testing.T) {
 	v := New[int]()
 	v.PushBack(1)
 	v.PushBack(2)

--- a/utils/comparator/comparator.go
+++ b/utils/comparator/comparator.go
@@ -1,5 +1,7 @@
 package comparator
 
+import "math"
+
 type Ordered interface {
 	Integer | Float | ~string
 }


### PR DESCRIPTION
I made official supports of `iter` package in Go standard for #33. Now we can try the range-based for-loops to iterate some of the types!

I use `//go:build go1.23` build tag for these files with new features to avoid breaking changes, like the code written in previous Go version (<1.23). I think this will not do harm to the users using older Go compilers.

All the types with naive Iterators are implemented with new `Iter()`, `Iter2()`, `IterMut()` and `IterMut2()`:

- `array`
- `deque`
- `bidlist`
- `simplelist`
- `treemap`: exclude `IterMut()`
- `rbtree`: exclude `IterMut()`
- `set`: only `Iter()`
- `slice`
- `vector`

Example for `array`:
```go
a := array.New[int](10)

// Iter()
for v := range a.Iter() {
    fmt.Println(v)
}

// IterMut()
for vPtr := range a.IterMut() {
    *vPtr *= 2
}

// Iter2()
for i, v := range a.Iter2() {
    fmt.Println(i, v)
}

// IterMut2()
for i, vPtr := range a.IterMut2() {
    *vPtr = i
}
```